### PR TITLE
Fix bug in f> f>= f< f<= 2-arity forms

### DIFF
--- a/src/clojure/uncomplicate/neanderthal/math.clj
+++ b/src/clojure/uncomplicate/neanderthal/math.clj
@@ -22,25 +22,25 @@
   ([^double x ^double y ^double nepsilons]
    (< (Precision/compareTo x y (* Precision/EPSILON nepsilons)) 0))
   ([^double x ^double y]
-   (< (Precision/compareTo x y Precision/EPSILON))))
+   (< (Precision/compareTo x y Precision/EPSILON) 0)))
 
 (defn f<=
   ([^double x ^double y ^double nepsilons]
    (<= (Precision/compareTo x y (* Precision/EPSILON nepsilons)) 0))
   ([^double x ^double y]
-   (<= (Precision/compareTo x y Precision/EPSILON))))
+   (<= (Precision/compareTo x y Precision/EPSILON) 0)))
 
 (defn f>
   ([^double x ^double y ^double nepsilons]
    (> (Precision/compareTo x y (* Precision/EPSILON nepsilons)) 0))
   ([^double x ^double y]
-   (> (Precision/compareTo x y Precision/EPSILON))))
+   (> (Precision/compareTo x y Precision/EPSILON) 0)))
 
 (defn f>=
   ([^double x ^double y ^double nepsilons]
    (>= (Precision/compareTo x y (* Precision/EPSILON nepsilons)) 0))
   ([^double x ^double y]
-   (>= (Precision/compareTo x y Precision/EPSILON))))
+   (>= (Precision/compareTo x y Precision/EPSILON) 0)))
 
 (defn pow-of-2? [^long n]
   (= 0 (bit-and n (- n 1))))


### PR DESCRIPTION
```clj
;; BEFORE FIX
uncomplicate.neanderthal.math=> (f< 2 1)
true
uncomplicate.neanderthal.math=> (f> 1 2)
true
uncomplicate.neanderthal.math=> (f<= 2 1)
true
uncomplicate.neanderthal.math=> (f>= 1 2)
true

;; AFTER FIX
uncomplicate.neanderthal.math=> (f< 2 1)
false
uncomplicate.neanderthal.math=> (f<= 2 1)
false
uncomplicate.neanderthal.math=> (f> 1 2)
false
uncomplicate.neanderthal.math=> (f>= 1 2)
```