### PR TITLE
Don't run clblast tests on unsuitable platforms.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ hs_*.log
 *.so
 */nrepl-port
 */target
+/.idea
+*.iml

--- a/test/uncomplicate/neanderthal/clblast_cpu_test.clj
+++ b/test/uncomplicate/neanderthal/clblast_cpu_test.clj
@@ -24,7 +24,9 @@
   (real-test/test-tr-trs factory tr)
   (real-test/test-tr-sv factory tr))
 
-(let [devs (devices (decent-platform (platforms) :cpu) :cpu)]
+(let [devs (some-> (platforms)
+                   (decent-platform :cpu)
+                   (devices :cpu))]
   (when (< 0 (count devs))
     (with-release [dev (first devs)
                    ctx (context [dev])


### PR DESCRIPTION
If one doesn't have CPU opencl tools installed the tests currently fail. This patch allows the test runner to skip over it.