### PR TITLE
Split `random.cl` into two files, one per precision

### DIFF
--- a/src/clojure/uncomplicate/neanderthal/internal/device/clblast.clj
+++ b/src/clojure/uncomplicate/neanderthal/internal/device/clblast.clj
@@ -2308,13 +2308,13 @@
     sy-eng))
 
 (let [src [(slurp (io/resource "uncomplicate/neanderthal/internal/device/opencl/blas-plus.cl"))
-           (slurp (io/resource "uncomplicate/neanderthal/internal/device/opencl/vect-math.cl"))
-           (slurp (io/resource "uncomplicate/neanderthal/internal/device/opencl/random.cl"))]]
+           (slurp (io/resource "uncomplicate/neanderthal/internal/device/opencl/vect-math.cl"))]]
 
   (org.jocl.blast.CLBlast/setExceptionsEnabled false)
 
   (defn clblast-double [ctx queue]
-    (let [dev (queue-device queue)
+    (let [src (conj src (slurp (io/resource "uncomplicate/neanderthal/internal/device/opencl/random-double.cl")))
+          dev (queue-device queue)
           wgs (max-work-group-size dev)
           apple? (clojure.string/includes? (name-info (platform dev)) "Apple")
           prog (build-program! (program-with-source ctx src)
@@ -2326,7 +2326,8 @@
                    (->DoubleTREngine ctx queue prog) (->DoubleSYEngine ctx queue prog))))
 
   (defn clblast-float [ctx queue]
-    (let [dev (queue-device queue)
+    (let [src (conj src (slurp (io/resource "uncomplicate/neanderthal/internal/device/opencl/random-float.cl")))
+          dev (queue-device queue)
           wgs (max-work-group-size dev)
           apple? (clojure.string/includes? (name-info (platform dev)) "Apple")
           prog (build-program! (program-with-source ctx src)

--- a/src/device/uncomplicate/neanderthal/internal/device/opencl/random-double.cl
+++ b/src/device/uncomplicate/neanderthal/internal/device/opencl/random-double.cl
@@ -1,9 +1,5 @@
 #include "Random123/philox.h"
 
-#ifndef M_2PI_FLOAT
-#define M_2PI_FLOAT 6.2831855f
-#endif
-
 #ifndef M_2PI_DOUBLE
 #define M_2PI_DOUBLE 6.283185307179586
 #endif
@@ -12,20 +8,8 @@
 #define NATIVE(fun) native_ ## fun
 #endif
 
-inline float u01_float(const uint32_t i) {
-    return (0.5f + (i >> 9)) * 0x1.0p-23f;
-}
-
 inline double u01_double(const uint64_t i) {
     return (0.5 + (i >> 12)) * 0x1.0p-52;
-}
-
-inline philox4x32_ctr_t rand_arr_32 (const uint64_t seed) {
-    const philox4x32_key_t key = {{seed, 0xdecafaaa}};
-    const philox4x32_ctr_t cnt = {{get_global_id(0), get_global_id(1),
-                                   get_global_id(2), 0xbeeff00d}};
-    const philox4x32_ctr_t rand = philox4x32(cnt, key);
-    return rand;
 }
 
 inline philox4x64_ctr_t rand_arr_64 (const uint64_t seed) {
@@ -34,17 +18,6 @@ inline philox4x64_ctr_t rand_arr_64 (const uint64_t seed) {
                                    get_global_id(2), 0xbeeff00d}};
     const philox4x64_ctr_t rand = philox4x64(cnt, key);
     return rand;
-}
-
-inline void box_muller_float(const uint32_t* i, float* g) {
-    g[0] = NATIVE(sin)(M_2PI_FLOAT * u01_float(i[0]))
-        * sqrt(-2.0f * NATIVE(log)(u01_float(i[1])));
-    g[1] = NATIVE(cos)(M_2PI_FLOAT * u01_float(i[0]))
-        * sqrt(-2.0f * NATIVE(log)(u01_float(i[1])));
-    g[2] = NATIVE(sin)(M_2PI_FLOAT * u01_float(i[2]))
-        * sqrt(-2.0f * NATIVE(log)(u01_float(i[3])));
-    g[3] = NATIVE(cos)(M_2PI_FLOAT * u01_float(i[2]))
-        * sqrt(-2.0f * NATIVE(log)(u01_float(i[3])));
 }
 
 inline void box_muller_double(const uint64_t* i, double* g) {
@@ -56,23 +29,6 @@ inline void box_muller_double(const uint64_t* i, double* g) {
         * sqrt(-2.0f * NATIVE(log)(u01_double(i[3])));
     g[3] = NATIVE(cos)(M_2PI_DOUBLE * u01_double(i[2]))
         * sqrt(-2.0f * NATIVE(log)(u01_double(i[3])));
-}
-
-__attribute__((work_group_size_hint(WGS, 1, 1)))
-__kernel void vector_uniform_float (const uint n, const ulong seed,
-                                    const float lower, const float upper,
-                                    __global float* x, const uint offset_x, const uint stride_x) {
-
-    const uint i = get_global_id(0) * 4;
-
-    const philox4x32_ctr_t rand = rand_arr_32(seed);
-    const float low = lower;
-    const float upplow = upper - low;
-
-    const uint limit = (i + 3) < n ? 4 : n - i;
-    for (uint j = 0; j < limit; j++) {
-        x[offset_x + ((i + j) * stride_x)] = u01_float(rand.v[j]) * upplow + low;
-    }
 }
 
 __attribute__((work_group_size_hint(WGS, 1, 1)))
@@ -93,22 +49,6 @@ __kernel void vector_uniform_double (const uint n, const ulong seed,
 }
 
 __attribute__((work_group_size_hint(WGS, 1, 1)))
-__kernel void vector_normal_float (const uint n, const ulong seed,
-                                   const float mu, const float sigma,
-                                   __global float* x, const uint offset_x, const uint stride_x) {
-
-    const uint i = get_global_id(0) * 4;
-
-    const philox4x32_ctr_t rand = rand_arr_32(seed);
-    float g[4];
-    box_muller_float(rand.v, g);
-    const uint limit = (i + 3) < n ? 4 : n - i;
-    for (uint j = 0; j < limit; j++) {
-        x[offset_x + ((i + j) * stride_x)] = g[j] * sigma + mu;
-    }
-}
-
-__attribute__((work_group_size_hint(WGS, 1, 1)))
 __kernel void vector_normal_double (const uint n, const ulong seed,
                                     const double mu, const double sigma,
                                     __global double* x, const uint offset_x, const uint stride_x) {
@@ -121,22 +61,6 @@ __kernel void vector_normal_double (const uint n, const ulong seed,
     const uint limit = (i + 3) < n ? 4 : n - i;
     for (uint j = 0; j < limit; j++) {
         x[offset_x + ((i + j) * stride_x)] = g[j] * sigma + mu;
-    }
-}
-
-__kernel void ge_uniform_float (const uint n, const ulong seed,
-                                const float lower, const float upper,
-                                __global float* a, const uint offset_a, const uint ld_a) {
-
-    const uint i = get_global_id(0) * 4;
-
-    const philox4x32_ctr_t rand = rand_arr_32(seed);
-    const float low = lower;
-    const float upplow = upper - low;
-
-    const uint limit = (i + 3) < n ? 4 : n - i;
-    for (uint j = 0; j < limit; j++) {
-        a[offset_a + i + j + get_global_id(1) * ld_a] = u01_float(rand.v[j]) * upplow + low;
     }
 }
 
@@ -153,22 +77,6 @@ __kernel void ge_uniform_double (const uint n, const ulong seed,
     const uint limit = (i + 3) < n ? 4 : n - i;
     for (uint j = 0; j < limit; j++) {
         a[offset_a + i + j + get_global_id(1) * ld_a] = u01_double(rand.v[j]) * upplow + low;
-    }
-}
-
-__kernel void ge_normal_float (const uint n, const ulong seed,
-                               const float mu, const float sigma,
-                               __global float* a, const uint offset_a, const uint ld_a) {
-
-    const uint i = get_global_id(0) * 4;
-
-    const philox4x32_ctr_t rand = rand_arr_32(seed);
-    float g[4];
-    box_muller_float(rand.v, g);
-
-    const uint limit = (i + 3) < n ? 4 : n - i;
-    for (uint j = 0; j < limit; j++) {
-        a[offset_a + i + j + get_global_id(1) * ld_a] = g[j] * sigma + mu;
     }
 }
 

--- a/src/device/uncomplicate/neanderthal/internal/device/opencl/random-float.cl
+++ b/src/device/uncomplicate/neanderthal/internal/device/opencl/random-float.cl
@@ -1,0 +1,97 @@
+#include "Random123/philox.h"
+
+#ifndef M_2PI_FLOAT
+#define M_2PI_FLOAT 6.2831855f
+#endif
+
+#ifndef NATIVE
+#define NATIVE(fun) native_ ## fun
+#endif
+
+inline float u01_float(const uint32_t i) {
+    return (0.5f + (i >> 9)) * 0x1.0p-23f;
+}
+
+inline philox4x32_ctr_t rand_arr_32 (const uint64_t seed) {
+    const philox4x32_key_t key = {{seed, 0xdecafaaa}};
+    const philox4x32_ctr_t cnt = {{get_global_id(0), get_global_id(1),
+                                   get_global_id(2), 0xbeeff00d}};
+    const philox4x32_ctr_t rand = philox4x32(cnt, key);
+    return rand;
+}
+
+inline void box_muller_float(const uint32_t* i, float* g) {
+    g[0] = NATIVE(sin)(M_2PI_FLOAT * u01_float(i[0]))
+        * sqrt(-2.0f * NATIVE(log)(u01_float(i[1])));
+    g[1] = NATIVE(cos)(M_2PI_FLOAT * u01_float(i[0]))
+        * sqrt(-2.0f * NATIVE(log)(u01_float(i[1])));
+    g[2] = NATIVE(sin)(M_2PI_FLOAT * u01_float(i[2]))
+        * sqrt(-2.0f * NATIVE(log)(u01_float(i[3])));
+    g[3] = NATIVE(cos)(M_2PI_FLOAT * u01_float(i[2]))
+        * sqrt(-2.0f * NATIVE(log)(u01_float(i[3])));
+}
+
+__attribute__((work_group_size_hint(WGS, 1, 1)))
+__kernel void vector_uniform_float (const uint n, const ulong seed,
+                                    const float lower, const float upper,
+                                    __global float* x, const uint offset_x, const uint stride_x) {
+
+    const uint i = get_global_id(0) * 4;
+
+    const philox4x32_ctr_t rand = rand_arr_32(seed);
+    const float low = lower;
+    const float upplow = upper - low;
+
+    const uint limit = (i + 3) < n ? 4 : n - i;
+    for (uint j = 0; j < limit; j++) {
+        x[offset_x + ((i + j) * stride_x)] = u01_float(rand.v[j]) * upplow + low;
+    }
+}
+
+__attribute__((work_group_size_hint(WGS, 1, 1)))
+__kernel void vector_normal_float (const uint n, const ulong seed,
+                                   const float mu, const float sigma,
+                                   __global float* x, const uint offset_x, const uint stride_x) {
+
+    const uint i = get_global_id(0) * 4;
+
+    const philox4x32_ctr_t rand = rand_arr_32(seed);
+    float g[4];
+    box_muller_float(rand.v, g);
+    const uint limit = (i + 3) < n ? 4 : n - i;
+    for (uint j = 0; j < limit; j++) {
+        x[offset_x + ((i + j) * stride_x)] = g[j] * sigma + mu;
+    }
+}
+
+__kernel void ge_uniform_float (const uint n, const ulong seed,
+                                const float lower, const float upper,
+                                __global float* a, const uint offset_a, const uint ld_a) {
+
+    const uint i = get_global_id(0) * 4;
+
+    const philox4x32_ctr_t rand = rand_arr_32(seed);
+    const float low = lower;
+    const float upplow = upper - low;
+
+    const uint limit = (i + 3) < n ? 4 : n - i;
+    for (uint j = 0; j < limit; j++) {
+        a[offset_a + i + j + get_global_id(1) * ld_a] = u01_float(rand.v[j]) * upplow + low;
+    }
+}
+
+__kernel void ge_normal_float (const uint n, const ulong seed,
+                               const float mu, const float sigma,
+                               __global float* a, const uint offset_a, const uint ld_a) {
+
+    const uint i = get_global_id(0) * 4;
+
+    const philox4x32_ctr_t rand = rand_arr_32(seed);
+    float g[4];
+    box_muller_float(rand.v, g);
+
+    const uint limit = (i + 3) < n ? 4 : n - i;
+    for (uint j = 0; j < limit; j++) {
+        a[offset_a + i + j + get_global_id(1) * ld_a] = g[j] * sigma + mu;
+    }
+}


### PR DESCRIPTION
Not all GPUs support double precision, so we're going to split the
random.cl file in two, one per precision, so that our opencl programs
compile on GPUs which only support single precision.

This PR started as issue [#31](https://github.com/uncomplicate/clojurecl/issues/31) in clojurecl. Let me know
if you'd like me to open a companion issue in this repo. I'm going to
close the clojurecl issue now.

I've tested this successfully with the following snippet, though this PR
does not contain any changes to test files, as my GPU doesn't support
double precision so I can't run the tests.

```clojure
(ns example
  (:require [uncomplicate.commons.core :as ccore]
            [uncomplicate.clojurecl.core :as opencl]
            [uncomplicate.neanderthal
             [core :as ncore]
             [opencl :as cl]
             [random :as nrandom]]
            [criterium.core :as crit]))

(opencl/with-default
  (cl/with-default-engine
    (ccore/with-release [gpu-a (nrandom/rand-uniform! (cl/clge 256 256))
                         gpu-b (nrandom/rand-uniform! (cl/clge 256 256))
                         gpu-c (ncore/zero gpu-a)]
      (crit/with-progress-reporting
        (crit/quick-bench
         (do (ncore/mm! (float 1.0) gpu-a gpu-b (float 0.0) gpu-c)
             (opencl/finish!)))))))
```