### PR TITLE
"minimal" example Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN git clone https://github.com/uncomplicate/neanderthal.git
 WORKDIR /tmp/neanderthal
 RUN git checkout e01511ff47605f2e4031d58899b303e4435d58e3
 
-RUN lein update-in :dependencies conj "[org.bytedeco/mkl-platform-redist \"2020.3-1.5.4\"]" -- test uncomplicate.neanderthal.mkl-test
+CMD  ["lein", "update-in" ,":dependencies", "conj" ,"[org.bytedeco/mkl-platform-redist \"2020.3-1.5.4\"]" ,"--", "test" ,"uncomplicate.neanderthal.mkl-test" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,40 @@
-# failing with
-# actual result:
-# clojure.lang.ExceptionInfo: LAPACK error. {:bad-argument 5, :error-code -5}
-#  uncomplicate.neanderthal.internal.host.mkl.FloatSYEngine.copy(mkl.clj:2065)
+FROM docker.io/ubuntu:focal
+RUN apt-get update && apt-get -y install --reinstall ca-certificates && update-ca-certificates
+RUN apt-get update && apt-get -y install
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-11-jdk curl rlwrap libssl-dev build-essential zlib1g-dev  libncurses5-dev \
+    libgdbm-dev libnss3-dev  libreadline-dev libffi-dev libbz2-dev  automake-1.15 git liblzma-dev wget git clinfo vim  \
+    leiningen software-properties-common
 
-FROM clojure:lein-2.9.8-focal
-RUN apt-get update && apt-get -y install git wget python3 cpio
-RUN wget http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16917/l_mkl_2020.4.304.tgz
-RUN tar xzf l_mkl_2020.4.304.tgz
-RUN cd l_mkl_2020.4.304 && ./install.sh -s silent.cfg --accept-eula
+# mkl . This might ask questions '??' Important ??
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y intel-mkl
+
+# CUDA 11.4 via official installer
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
+RUN mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+RUN wget https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda-repo-ubuntu2004-11-4-local_11.4.1-470.57.02-1_amd64.deb
+RUN dpkg -i cuda-repo-ubuntu2004-11-4-local_11.4.1-470.57.02-1_amd64.deb
+RUN apt-key add /var/cuda-repo-ubuntu2004-11-4-local/7fa2af80.pub
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install cuda
+
+# opencl
+RUN apt-get install -y vim nvidia-opencl-dev intel-opencl-icd
+
+
+#cudnn via official installer
+ENV cudnn_version=8.2.4.15
+ENV cuda_version=cuda11.4
+ENV OS=ubuntu2004
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/${OS}/x86_64/cuda-${OS}.pin
+RUN mv cuda-${OS}.pin /etc/apt/preferences.d/cuda-repository-pin-600
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys A4B469963BF863CC
+RUN add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/${OS}/x86_64/ /"
+RUN apt-get update
+RUN apt-get install libcudnn8=${cudnn_version}-1+${cuda_version}
+RUN apt-get install libcudnn8-dev=${cudnn_version}-1+${cuda_version}
+
+# clone neanderthal, temporay stuff just to ease to run the tests
+WORKDIR /tmp
 RUN git clone https://github.com/uncomplicate/neanderthal.git
-
 WORKDIR /tmp/neanderthal
-RUN git checkout e01511ff47605f2e4031d58899b303e4435d58e3
-ENV LD_LIBRARY_PATH="/opt/intel/mkl/lib/intel64/"
-CMD  ["lein", "update-in" ,":dependencies", "conj" ,"[org.bytedeco/mkl-platform-redist \"2020.3-1.5.4\"]" ,"--", "test" ,"uncomplicate.neanderthal.mkl-test" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM clojure:lein-2.9.8-focal
 RUN apt-get update && apt-get -y install git wget python3
 RUN wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_2022.1.0.223.sh
-# RUN sh ./l_onemkl_p_2022.1.0.223.sh -a --silent  --eula accept
+RUN sh ./l_onemkl_p_2022.1.0.223.sh -a --silent  --eula accept
 
 # RUN git clone https://github.com/uncomplicate/neanderthal.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# failing with
+# Execution error (UnsatisfiedLinkError) at java.lang.ClassLoader$NativeLibrary/load0 (ClassLoader.java:-2).
+#/tmp/libneanderthal-mkl-0.33.07653633467081296505.so: libmkl_rt.so: cannot open shared object file: No such file or directory
+
+FROM clojure:lein-2.9.8-focal
+RUN apt-get update && apt-get -y install git wget python3
+RUN wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18673/l_BaseKit_p_2022.2.0.262_offline.sh
+RUN wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_2022.1.0.223.sh
+RUN sh ./l_onemkl_p_2022.1.0.223.sh -a --silent  --eula accept
+
+#RUN git clone https://github.com/uncomplicate/deep-diamond.git
+RUN git clone https://github.com/uncomplicate/neanderthal.git
+
+WORKDIR /tmp/neanderthal
+RUN git checkout e01511ff47605f2e4031d58899b303e4435d58e3
+#RUN lein test uncomplicate.neanderthal.mkl-test
+
+RUN lein update-in :dependencies conj "[org.bytedeco/mkl-platform-redist \"2020.3-1.5.4\"]" -- test uncomplicate.neanderthal.mkl-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update && apt-get -y install git wget python3
 RUN wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_2022.1.0.223.sh
 RUN sh ./l_onemkl_p_2022.1.0.223.sh -a --silent  --eula accept
 
-# RUN git clone https://github.com/uncomplicate/neanderthal.git
+RUN git clone https://github.com/uncomplicate/neanderthal.git
 
-# WORKDIR /tmp/neanderthal
-# RUN git checkout e01511ff47605f2e4031d58899b303e4435d58e3
+WORKDIR /tmp/neanderthal
+RUN git checkout e01511ff47605f2e4031d58899b303e4435d58e3
 
 RUN lein update-in :dependencies conj "[org.bytedeco/mkl-platform-redist \"2020.3-1.5.4\"]" -- test uncomplicate.neanderthal.mkl-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,12 @@
 
 FROM clojure:lein-2.9.8-focal
 RUN apt-get update && apt-get -y install git wget python3
-RUN wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18673/l_BaseKit_p_2022.2.0.262_offline.sh
 RUN wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_2022.1.0.223.sh
-RUN sh ./l_onemkl_p_2022.1.0.223.sh -a --silent  --eula accept
+# RUN sh ./l_onemkl_p_2022.1.0.223.sh -a --silent  --eula accept
 
-#RUN git clone https://github.com/uncomplicate/deep-diamond.git
-RUN git clone https://github.com/uncomplicate/neanderthal.git
+# RUN git clone https://github.com/uncomplicate/neanderthal.git
 
-WORKDIR /tmp/neanderthal
-RUN git checkout e01511ff47605f2e4031d58899b303e4435d58e3
-#RUN lein test uncomplicate.neanderthal.mkl-test
+# WORKDIR /tmp/neanderthal
+# RUN git checkout e01511ff47605f2e4031d58899b303e4435d58e3
 
 RUN lein update-in :dependencies conj "[org.bytedeco/mkl-platform-redist \"2020.3-1.5.4\"]" -- test uncomplicate.neanderthal.mkl-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 # failing with
-# Execution error (UnsatisfiedLinkError) at java.lang.ClassLoader$NativeLibrary/load0 (ClassLoader.java:-2).
-#/tmp/libneanderthal-mkl-0.33.07653633467081296505.so: libmkl_rt.so: cannot open shared object file: No such file or directory
+# actual result:
+# clojure.lang.ExceptionInfo: LAPACK error. {:bad-argument 5, :error-code -5}
+#  uncomplicate.neanderthal.internal.host.mkl.FloatSYEngine.copy(mkl.clj:2065)
 
 FROM clojure:lein-2.9.8-focal
-RUN apt-get update && apt-get -y install git wget python3
-RUN wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_2022.1.0.223.sh
-RUN sh ./l_onemkl_p_2022.1.0.223.sh -a --silent  --eula accept
-
+RUN apt-get update && apt-get -y install git wget python3 cpio
+RUN wget http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16917/l_mkl_2020.4.304.tgz
+RUN tar xzf l_mkl_2020.4.304.tgz
+RUN cd l_mkl_2020.4.304 && ./install.sh -s silent.cfg --accept-eula
 RUN git clone https://github.com/uncomplicate/neanderthal.git
 
 WORKDIR /tmp/neanderthal
 RUN git checkout e01511ff47605f2e4031d58899b303e4435d58e3
-
+ENV LD_LIBRARY_PATH="/opt/intel/mkl/lib/intel64/"
 CMD  ["lein", "update-in" ,":dependencies", "conj" ,"[org.bytedeco/mkl-platform-redist \"2020.3-1.5.4\"]" ,"--", "test" ,"uncomplicate.neanderthal.mkl-test" ]

--- a/example-docker/Dockerfile
+++ b/example-docker/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update && apt-get -y install --reinstall ca-certificates && update-c
 RUN apt-get update && apt-get -y install
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-11-jdk curl rlwrap libssl-dev build-essential zlib1g-dev  libncurses5-dev \
     libgdbm-dev libnss3-dev  libreadline-dev libffi-dev libbz2-dev  automake-1.15 git liblzma-dev wget git clinfo vim  \
-    leiningen software-properties-common
+    leiningen software-properties-common vim
 
 # mkl . This might ask questions '??' Important ??
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y intel-mkl
@@ -17,8 +17,6 @@ RUN apt-key add /var/cuda-repo-ubuntu2004-11-4-local/7fa2af80.pub
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install cuda
 
-# opencl
-RUN apt-get install -y vim nvidia-opencl-dev intel-opencl-icd
 
 
 #cudnn via official installer
@@ -33,8 +31,16 @@ RUN apt-get update
 RUN apt-get install libcudnn8=${cudnn_version}-1+${cuda_version}
 RUN apt-get install libcudnn8-dev=${cudnn_version}-1+${cuda_version}
 
+#opencl
+RUN apt-get install -y libnvidia-compute-515 nvidia-opencl-dev intel-opencl-icd
 # clone neanderthal, temporay stuff just to ease to run the tests
-WORKDIR /tmp
-RUN git clone https://github.com/uncomplicate/neanderthal.git
-WORKDIR /tmp/neanderthal
 
+RUN curl -O https://download.clojure.org/install/linux-install-1.11.1.1149.sh
+RUN chmod +x linux-install-1.11.1.1149.sh
+RUN ./linux-install-1.11.1.1149.sh
+
+COPY deps.edn.minimal /tmp/deps.edn
+WORKDIR /tmp
+
+# from know onwards neandertthal is setup with MKL, Cuda, OpenCL
+CMD ["clj" , "-M:nREPL",  "-m" , "nrepl.cmdline"]

--- a/example-docker/deps.edn.minimal
+++ b/example-docker/deps.edn.minimal
@@ -1,0 +1,8 @@
+{:deps
+ {uncomplicate/neanderthal {:mvn/version "0.44.0"}
+ org.jcuda/jcuda {:mvn/version "11.4.1"}
+ org.jcuda/jcublas {:mvn/version "11.4.1"}
+ nrepl/nrepl {:mvn/version "0.9.0"}
+}
+
+}


### PR DESCRIPTION
It setups MKL, CUDA and openCL based on Ubuntu 20.04 Dockerimage.

Maybe worth to keep and mention as an additional way of setting up of neanthertal.

I went for CUDA 11.4, so we need overwrite jcuda deps, as shown in `deps.edn.minimal`