### PR TITLE
Change project.clj classifier from symbol to string

### DIFF
--- a/examples/benchmarks/project.clj
+++ b/examples/benchmarks/project.clj
@@ -6,8 +6,8 @@
 
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [uncomplicate/neanderthal "0.48.0-SNAPSHOT"]
-                 [org.bytedeco/mkl "2023.1-1.5.10-SNAPSHOT" :classifier linux-x86_64-redist]
-                 [org.bytedeco/cuda "12.1-8.9-1.5.10-SNAPSHOT" :classifier linux-x86_64-redist]
+                 [org.bytedeco/mkl "2023.1-1.5.10-SNAPSHOT" :classifier "linux-x86_64-redist"]
+                 [org.bytedeco/cuda "12.1-8.9-1.5.10-SNAPSHOT" :classifier "linux-x86_64-redist"]
                  [criterium "0.4.6"]
                  [prismatic/hiphip "0.2.1"]
                  [net.mikera/core.matrix "0.63.0"]

--- a/examples/hello-world-aot/project.clj
+++ b/examples/hello-world-aot/project.clj
@@ -8,12 +8,12 @@
              :default/all {:dependencies [[codox-theme-rdash "0.1.2"]
                                           ;; optional
                                           [org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT"]]}
-             :linux {:dependencies [[org.bytedeco/mkl "2025.0-1.5.11" :classifier linux-x86_64-redist]
+             :linux {:dependencies [[org.bytedeco/mkl "2025.0-1.5.11" :classifier "linux-x86_64-redist"]
                                     ;; optional, if you want GPU computing with CUDA. Beware: the jar size is 3GB!
-                                    [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier linux-x86_64-redist]]}
-             :windows {:dependencies [[org.bytedeco/mkl "2025.0-1.5.11" :classifier windows-x86_64-redist]
+                                    [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier "linux-x86_64-redist"]]}
+             :windows {:dependencies [[org.bytedeco/mkl "2025.0-1.5.11" :classifier "windows-x86_64-redist"]
                                       ;; optional, if you want GPU computing with CUDA. Beware: the jar size is 3GB!
-                                      [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier windows-x86_64-redist]]}
+                                      [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier "windows-x86_64-redist"]]}
              :macosx {:dependencies []}}
 
   ;; Wee need this for the snapshots!

--- a/examples/hello-world/project.clj
+++ b/examples/hello-world/project.clj
@@ -17,18 +17,18 @@
   :profiles {:default [:default/all ~(leiningen.core.utils/get-os)]
              :default/all {:dependencies [[codox-theme-rdash "0.1.2"]
                                           [org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT"]]}
-             :linux {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier linux-x86_64]
+             :linux {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier "linux-x86_64"]
                                     [org.uncomplicate/neanderthal-mkl "0.54.0-SNAPSHOT"]
-                                    [org.bytedeco/mkl "2025.0-1.5.11" :classifier linux-x86_64-redist]
+                                    [org.bytedeco/mkl "2025.0-1.5.11" :classifier "linux-x86_64-redist"]
                                     [org.uncomplicate/neanderthal-cuda "0.54.0-SNAPSHOT"]
-                                    [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier linux-x86_64-redist]]}
+                                    [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier "linux-x86_64-redist"]]}
              :windows {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier windows-x86_64]
                                       [org.uncomplicate/neanderthal-mkl "0.54.0-SNAPSHOT"]
-                                      [org.bytedeco/mkl "2025.0-1.5.11" :classifier windows-x86_64-redist]
+                                      [org.bytedeco/mkl "2025.0-1.5.11" :classifier "windows-x86_64-redist"]
                                       [org.uncomplicate/neanderthal-cuda "0.54.0-SNAPSHOT"]
-                                      [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier windows-x86_64-redist]]}
+                                      [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier "windows-x86_64-redist"]]}
              :macosx {:dependencies [[org.uncomplicate/neanderthal-accelerate "0.54.0-SNAPSHOT"]
-                                     [org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier macosx-arm64]]}}
+                                     [org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier "macosx-arm64"]]}}
 
   ;; Wee need this for the snapshots!
   :repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]

--- a/neanderthal-accelerate/project.clj
+++ b/neanderthal-accelerate/project.clj
@@ -29,7 +29,7 @@
                    :dependencies [[codox-theme-rdash "0.1.2"]
                                   [midje "1.10.10"]
                                   [org.uncomplicate/neanderthal-test "0.54.0-SNAPSHOT"]
-                                  [org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier macosx-arm64]]
+                                  [org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier "macosx-arm64"]]
                    :jvm-opts ^:replace ["-Dclojure.compiler.direct-linking=true"
                                         "--enable-native-access=ALL-UNNAMED"]}}
 

--- a/neanderthal-aot/project.clj
+++ b/neanderthal-aot/project.clj
@@ -42,13 +42,13 @@
                                      *print-length* 128}
                        :dependencies [[codox-theme-rdash "0.1.2"]
                                       [midje "1.10.10"]]}
-             :linux {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier linux-x86_64]
-                                    [org.bytedeco/mkl "2025.0-1.5.11" :classifier linux-x86_64-redist]
-                                    [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier linux-x86_64-redist]]}
-             :windows {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier windows-x86_64]
-                                      [org.bytedeco/mkl "2025.0-1.5.11" :classifier windows-x86_64-redist]
-                                      [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier windows-x86_64-redist]]}
-             :macosx {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier macosx-arm64]]}}
+             :linux {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier "linux-x86_64"]
+                                    [org.bytedeco/mkl "2025.0-1.5.11" :classifier "linux-x86_64-redist"]
+                                    [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier "linux-x86_64-redist"]]}
+             :windows {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier "windows-x86_64"]
+                                      [org.bytedeco/mkl "2025.0-1.5.11" :classifier "windows-x86_64-redist"]
+                                      [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier "windows-x86_64-redist"]]}
+             :macosx {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier "macosx-arm64"]]}}
 
   :repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]
 

--- a/neanderthal-apple/project.clj
+++ b/neanderthal-apple/project.clj
@@ -19,7 +19,7 @@
                  [org.uncomplicate/neanderthal-base "0.54.0-SNAPSHOT"]
                  [org.uncomplicate/neanderthal-openblas "0.54.0-SNAPSHOT"]
                  [org.uncomplicate/neanderthal-accelerate "0.54.0-SNAPSHOT"]
-                 [org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier macosx-arm64]]
+                 [org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier "macosx-arm64"]]
 
   :aot [uncomplicate.neanderthal.internal.cpp.structures
         uncomplicate.neanderthal.internal.cpp.factory

--- a/neanderthal-cuda/project.clj
+++ b/neanderthal-cuda/project.clj
@@ -38,10 +38,10 @@
                                :output-path "../docs/codox"}
                        :jvm-opts ^:replace ["-Dclojure.compiler.direct-linking=true"
                                              "--enable-native-access=ALL-UNNAMED"]}
-             :linux {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier linux-x86_64]
-                                    [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier linux-x86_64-redist]]}
-             :windows {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier windows-x86_64]
-                                      [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier windows-x86_64-redist]]}}
+             :linux {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier "linux-x86_64"]
+                                    [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier "linux-x86_64-redist"]]}
+             :windows {:dependencies [[org.bytedeco/openblas "0.3.29-1.5.12-SNAPSHOT" :classifier "windows-x86_64"]
+                                      [org.bytedeco/cuda "12.9-9.9-1.5.12-SNAPSHOT" :classifier "windows-x86_64-redist"]]}}
 
   :repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]
 

--- a/neanderthal-mkl/project.clj
+++ b/neanderthal-mkl/project.clj
@@ -31,8 +31,8 @@
                                       [org.uncomplicate/neanderthal-test "0.54.0-SNAPSHOT"]]
                        :jvm-opts ^:replace ["-Dclojure.compiler.direct-linking=true"
                                             "--enable-native-access=ALL-UNNAMED"]}
-             :linux {:dependencies [[org.bytedeco/mkl "2025.0-1.5.11" :classifier linux-x86_64-redist]]}
-             :windows {:dependencies [[org.bytedeco/mkl "2025.0-1.5.11" :classifier windows-x86_64-redist]]}}
+             :linux {:dependencies [[org.bytedeco/mkl "2025.0-1.5.11" :classifier "linux-x86_64-redist"]]}
+             :windows {:dependencies [[org.bytedeco/mkl "2025.0-1.5.11" :classifier "windows-x86_64-redist"]]}}
 
   :repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots"]]
 


### PR DESCRIPTION
Having it as a symbol breaks some tooling, notably Cursive clojure. But in the Leiningen sample it's also a string, not a symbol.